### PR TITLE
Fixes string replacement for api service names with multiple slashes.

### DIFF
--- a/web/openshift/templates/nginx-runtime/s2i/bin/run
+++ b/web/openshift/templates/nginx-runtime/s2i/bin/run
@@ -64,7 +64,7 @@ getApiUrl (){
   #   Results in API_URL=https://django-devex-von-dev.pathfinder.gov.bc.ca/api/v1/   
   # ================================================================================
   if [ ! -z "${API_SERVICE_NAME}" ]; then
-    _SERVICE_NAME="$(tr '[:lower:]' '[:upper:]' <<< ${API_SERVICE_NAME/-/_})"
+    _SERVICE_NAME="$(tr '[:lower:]' '[:upper:]' <<< ${API_SERVICE_NAME//-/_})"
     _SERVICE_HOST_NAME=${_SERVICE_NAME}_SERVICE_HOST
     _SERVICE_PORT_NAME=${_SERVICE_NAME}_SERVICE_PORT
 


### PR DESCRIPTION
See https://github.com/bcgov/TheOrgBook/pull/867

Signed-off-by: Wade Barnes <wade.barnes@shaw.ca>